### PR TITLE
GIT-13: Standardize acronym definition styles

### DIFF
--- a/docs/glossary.mdx
+++ b/docs/glossary.mdx
@@ -7,16 +7,16 @@ route: /glossary
 
 ## Development
 
-- **ABI** A JSON description of the external interface for a Contract Instance, or for the description of common interface of all instances of a Contract Type.
-- **EOA** Externally owned account. An account that is controlled by a private key (as opposed to smart contract code).
+- **ABI** (Application Binary Interface) A JSON description of the external interface for a Contract Instance, or for the description of common interface of all instances of a Contract Type.
+- **EOA** (Externally Owned Account) An account that is controlled by a private key (as opposed to smart contract code).
 - **Gas** An independent unit of account for pricing smart contract computations and transactions on the Ethereum network.
 - **Remix** A [browser-based IDE](https://remix.ethereum.org) for Solidity and Vyper with integrated debugging, testing, and a virtual blockchain for convenient smart contract development.
 
 ## Ethereum
 
 - **Address** 0x-prefixed hexadecimal string representing an account’s public identifier
-- **ENS** Ethereum Name Service. A smart contract based registration and resolution system for mapping Ethereum addresses to human-readable names.
-- **EVM** The Ethereum Virtual Machine. The runtime environment for Ethereum smart contracts.
+- **ENS** (Ethereum Name Service) A smart contract based registration and resolution system for mapping Ethereum addresses to human-readable names.
+- **EVM** (Ethereum Virtual Machine) The runtime environment for Ethereum smart contracts.
 - **Layer 2 (L2)** Scaling mechanisms that are not part of the core protocol, but utilize the root chain for security.
 - **Solidity** The most fully supported programming language (of a handful of options) that can be readily compiled into bytecode for the EVM.
-- **UTXO** Unspent Transaction Output - The outputs of a blockchain transaction that are available as inputs for another transaction.
+- **UTXO** (Unspent Transaction Output) The outputs of a blockchain transaction that are available as inputs for another transaction.


### PR DESCRIPTION
#### Description: ✍️
Per discussion, went with option three since that seems to be the _proper_ way to present acronym definitions.

#### Issue(s): 🎟️
#13 
Low participation? Used the Google oracle? ;-)

#### Visual: 🔍
n/a

#### Reference(s): 📖
https://proofreadmyessay.co.uk/writing-tips/using-acronyms/