### PR TITLE
Add reference links for private computation and transaction services

### DIFF
--- a/docs/services.mdx
+++ b/docs/services.mdx
@@ -39,3 +39,10 @@ route: /services
 - [Hedgehog](https://hedgehog.audius.co)
 - [Ledger](https://www.ledger.com/)
 - [MetaMask](https://metamask.io)
+
+## Private Computation Protocols
+- [Oasis](https://www.oasislabs.com/)
+- [Enigma](https://enigma.co/)
+
+## Private Transaction Protocols
+- [Aztec](https://www.aztecprotocol.com/)


### PR DESCRIPTION
#### Description: ✍️
Add sections and links to current private computation and transaction protocols.

#### Issue(s): 🎟️
None.

#### Visual: 🔍
![Screen Shot 2019-06-16 at 9 12 19 PM](https://user-images.githubusercontent.com/3644777/59578100-78963d80-907b-11e9-8179-39f16fd21e7e.png)


#### Reference(s): 📖
https://www.oasislabs.com/
https://enigma.co/
https://www.aztecprotocol.com/